### PR TITLE
Fix saving errors

### DIFF
--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -290,8 +290,7 @@ class LimaCCDTwoDController(TwoDController, Referable):
 
             self._limaccd.write_attribute('saving_prefix', prefix)
 
-            # TODO: include scheme
-            image_pattern = '{dir}/{prefix}{{0:{idx_fmt}}}{suffix}'
+            image_pattern = 'file://{dir}/{prefix}{{0:{idx_fmt}}}{suffix}'
             self._image_pattern = image_pattern.format(dir=directory,
                                                        prefix=prefix,
                                                        idx_fmt=idx_fmt,

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -322,8 +322,12 @@ class LimaCCDTwoDController(TwoDController, Referable):
                     or not flg_same_index_fmt:
                 self._limaccd.write_attribute('saving_prefix', prefix)
 
-            image_pattern = 'file://{dir}/{prefix}{{0:{idx_fmt}}}{suffix}'
-            self._image_pattern = image_pattern.format(dir=directory,
+            scheme = 'file'
+            if format == 'HDF5':
+                scheme = 'h5file'
+            image_pattern = '{scheme}://{dir}/{prefix}{{0:{idx_fmt}}}{suffix}'
+            self._image_pattern = image_pattern.format(scheme=scheme,
+                                                       dir=directory,
                                                        prefix=prefix,
                                                        idx_fmt=idx_fmt,
                                                        suffix=suffix)

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -276,6 +276,7 @@ class LimaCCDTwoDController(TwoDController, Referable):
             for keyword in keywords:
                 key, value = keyword.split(':')
                 if key.lower() == 'index':
+                    value = value.split('d')[0]
                     index_format = '%{0}d'.format(value)
                     idx_fmt = value
                     self._limaccd.write_attribute('saving_index_format',


### PR DESCRIPTION
The LimaCCD DS reset the saving next number when the prefix is written, it generates errors if the saving mode is "abort" or overwrite the previous images if the saving mode is "overwrite". In this case the controller only writes if there are different on the saving configuration (directory, format, prefix, etc.) 

In addition add the scheme for HDF5 and allow to create the VDS on the HDF5 recorder. Note it is only works with python-h5py 2.10