### PR TITLE
Add empirical delay time as property

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -268,6 +268,7 @@ class Saving(object):
     def __init__(self, lima):
         self.lima = lima
         self.first_image_nb = 0
+        self.delay_time = 0.05
         self.enabled = False
         self.pattern = ""
         self.config = {}
@@ -293,7 +294,7 @@ class Saving(object):
         self.lima[names] = values
         if self.first_image_nb != 0:
             self.lima["saving_next_number"] = -1
-            time.sleep(0.05) # empirical value?
+            time.sleep(self.delay_time)  # empirical value?
             self.lima["saving_prefix"] = config["saving_prefix"]
             monotonic = getattr(time, "monotonic", time.time)
             t0 = monotonic()

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -99,6 +99,12 @@ class LimaCtrlMixin(object):
             DefaultValue: 0,
             Description: 'First value of the saving next number'
         },
+        'FirstImageNumberDelayTime': {
+            Type: float,
+            DefaultValue: 0.05,
+            Description: 'Sleep time required to let Lima set the first image '
+                         'number'
+        },
         'MasterTrigger': {
             Type: bool,
             DefaultValue: False,
@@ -181,6 +187,7 @@ class LimaCtrlMixin(object):
         self._ctrl_class = ctrl_class
         self._lima = Lima(self.LimaCCDDeviceName,  self._log)
         self._lima.saving.first_image_nb = self.FirstImageNumber
+        self._lima.saving.delay_time = self.FirstImageNumberDelayTime
         self._latency_time = self.LatencyTime
         self._acquisition = None
         try:


### PR DESCRIPTION
Add property to fine tuning the necessary delay time to let Lima set the first image number under any overwrite policy condition.