### PR TITLE
Apply workaround for xspress3 (not compatibile with INTERNAL_TRIGGER_MULTI

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -325,6 +325,7 @@ class Lima(object):
         self._device_name = device_name
         self._device = None
         self._capabilities = None
+        self._camera_type = None
         self.saving = Saving(self)
 
     def __call__(self, name, *args):
@@ -357,6 +358,12 @@ class Lima(object):
                 for cap in self.CAPABILITIES
             }
         return self._capabilities
+    
+    @property
+    def camera_type(self):
+        if self._camera_type is None:
+            self._camera_type = self["camera_type"]
+        return self._camera_type
 
     def acquisition(self, nb_points, nb_starts, expo_time, latency_time, trigger_mode):
         return Acquisition(

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -214,7 +214,8 @@ class LimaCtrlMixin(object):
     def calc_trigger_mode(self):
         trigger_mode = TRIGGER_MAP[self._synchronization]
         if trigger_mode == "INTERNAL_TRIGGER_MULTI":
-            if trigger_mode not in self._lima.capabilities["acq_trigger_mode"]:
+            if (trigger_mode not in self._lima.capabilities["acq_trigger_mode"]
+                    or self._lima.camera_type == "xspress3"):
                 trigger_mode = "INTERNAL_TRIGGER"
         elif trigger_mode not in self._lima.capabilities["acq_trigger_mode"]:
             raise ValueError("trigger mode {0} not supported".format(trigger_mode))


### PR DESCRIPTION
Xspress3 never changes ready_for_next_image to True. This makes measurement process
to stuck on the first frame (state never changes to ON).
Do not use this mode and fallback to INTERNAL_TRIGGER.

Looks like we will need to live with this workaround still for longer time - until CSBL-5408 gets resolved.