### PR TITLE
Fix step scans with hardware synchronization

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -221,7 +221,7 @@ class Acquisition(object):
                 # in hardware trigger, if there are multiple starts it means we
                 # are probably in a step scan so we need to report ready so
                 # that sardana calls ReadOne/RefOne to consume the point
-                if idx_finished >= self.get_next_number():
+                if self.get_next_number() + idx_finished >= self.get_next_number():
                     acq_status = "Ready"
         return acq_status
 


### PR DESCRIPTION
Step scans with hardware synchronization do not work when LimaCCD attribute `saving_next_number` (`next_number`) is different than 0 at the beginning of the scan.

This is because the `last_image_ready` and `last_image_saved` LimaCCD attributes (`idx_ready` and `idx_saved` variables respectively, or simply `idx_finished`) are always -1 at the beginning of the scan causing a _gap_ between these two counters.

Solve it by bringing the `idx_finished` to the common base with `next_number` before the comparison.