### PR TITLE
add scan_dir as parameter in lima_hook

### DIFF
--- a/sardana_limaccd/__init__.py
+++ b/sardana_limaccd/__init__.py
@@ -1,3 +1,3 @@
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -292,8 +292,13 @@ class Saving(object):
         self.config = config = saving_for_pattern(self.pattern)
         config["saving_mode"] = "AUTO_FRAME"
         config["saving_overwrite_policy"] = "ABORT"
-        names, values = zip(*config.items())
-        self.lima[names] = values
+        attr_ordered = ['saving_mode', 'saving_overwrite_policy',
+                        'saving_directory', 'saving_format',
+                        'saving_suffix', 'saving_index_format',
+                        'saving_prefix']
+        for name in attr_ordered:
+            self.lima[name] = self.config[name]
+
         if self.first_image_nb != 0:
             self.lima["saving_next_number"] = -1
             time.sleep(self.delay_time)  # empirical value?

--- a/sardana_limaccd/ctrl/LimaRoICounterCtrl.py
+++ b/sardana_limaccd/ctrl/LimaRoICounterCtrl.py
@@ -209,7 +209,7 @@ class LimaRoICounterCtrl(CounterTimerController):
                 # readings of the counter evolution
                 if len(self._data_buff[axis]) == 0:
                     raise Exception('Acquisition did not finish correctly.')
-                value = self._data_buff[axis][0]
+                value = int(self._data_buff[axis][0])
             else:
                 value = self._data_buff[axis]
         except Exception as e:

--- a/sardana_limaccd/ctrl/LimaRoICounterCtrl.py
+++ b/sardana_limaccd/ctrl/LimaRoICounterCtrl.py
@@ -198,7 +198,8 @@ class LimaRoICounterCtrl(CounterTimerController):
                     self._data_buff[axis] += [rois_data[sum_idx]]
             self._log.debug('Read images [%d, %d]' % (self._last_image_read,
                                                       self._last_image_ready))
-            if not self._synchronization == AcqSynch.SoftwareTrigger:
+            if self._synchronization in [AcqSynch.HardwareTrigger,
+                                         AcqSynch.HardwareGate]:
                 self._last_image_read = self._last_image_ready
 
     def ReadOne(self, axis):

--- a/sardana_limaccd/macro/limaccd.py
+++ b/sardana_limaccd/macro/limaccd.py
@@ -158,9 +158,12 @@ class lima_hook(Macro):
     lima configuration environment:
     <ScanDir>/<directory>/<scan_sub_dir>/<prefix>{index:<index>}<suffix>
     """
+    param_def = [['scan_dir', Type.String, Optional, '']]
+        
     def run(self):
         conf = get_env(self)
-        scan_dir = self.getEnv('ScanDir')
+        if scan_dir is None:
+            scan_dir = self.getEnv('ScanDir')
         scan_id = self.getEnv('ScanID')
         mg_active = self.getEnv('ActiveMntGrp')
         mg = self.getMeasurementGroup(mg_active)

--- a/sardana_limaccd/macro/limaccd.py
+++ b/sardana_limaccd/macro/limaccd.py
@@ -16,7 +16,6 @@ def get_env(macro_obj):
     return conf
 
 
-
 # class reconfig_lima(Macro):
 #     """
 #     Macro to be sure that the configuration of the lima is correct
@@ -33,7 +32,7 @@ class set_lima_conf(Macro):
       "suffix": ".h5",
       "index": "05d",
       "scan_sub_dir": "scan_{ScanID:04d}",
-      "directory": "xp3"
+      "directory": "{ScanDir}/xp3"
 
     """
     param_def = [
@@ -62,7 +61,7 @@ class get_lima_conf(Macro):
       "suffix": ".h5",
       "index": "05d",
       "scan_sub_dir": "scan_{ScanID:04d}",
-      "directory": "xp3"
+      "directory": "{ScanDir}/xp3"
 
     """
     param_def = [
@@ -96,7 +95,7 @@ class def_lima_conf(Macro):
         suffix: ".edf",
         index: "04d",
         scan_sub_dir: "scan_{ScanID:04d}",
-        directory: <lima_channel>
+        directory: "{ScanDir}/<lima_channel>"
     """
     param_def = [['lima_channel', Type.TwoDExpChannel, None, ''],
                  ['parameters', [
@@ -118,7 +117,7 @@ class def_lima_conf(Macro):
                        "suffix": ".edf",
                        "index": "04d",
                        "scan_sub_dir": "scan_{ScanID:04d}",
-                       "directory": "{}".format(lima_channel)}
+                       "directory": "{{ScanDir}}/{}".format(lima_channel)}
 
         conf[alias].update(dict(parameters))
         self.setEnv(LIMA_ENV, conf)
@@ -132,7 +131,7 @@ class udef_lima_conf(Macro):
         suffix: ".edf",
         index: "04d",
         scan_sub_dir: "scan_{ScanID:04d}",
-        directory: <lima_channel>
+        directory: {ScanDir}/<lima_channel>
     """
     param_def = [['lima_channel', Type.TwoDExpChannel, None, '']]
 
@@ -156,14 +155,12 @@ class lima_hook(Macro):
     """
     Macro to configure ValueRefPattern of the Lima channel according to  the
     lima configuration environment:
-    <ScanDir>/<directory>/<scan_sub_dir>/<prefix>{index:<index>}<suffix>
+    <directory>/<scan_sub_dir>/<prefix>{index:<index>}<suffix>
     """
-    param_def = [['scan_dir', Type.String, Optional, '']]
-        
+
     def run(self):
         conf = get_env(self)
-        if scan_dir is None:
-            scan_dir = self.getEnv('ScanDir')
+        scan_dir = self.getEnv('ScanDir')
         scan_id = self.getEnv('ScanID')
         mg_active = self.getEnv('ActiveMntGrp')
         mg = self.getMeasurementGroup(mg_active)
@@ -172,9 +169,11 @@ class lima_hook(Macro):
             if element not in conf:
                 continue
             # Prepare the Value Reference Pattern for the element
-            lima_dir = conf[element]['directory']
+            # directory may contain <ScanDir>
+            lima_dir = conf[element]['directory'].format(ScanDir=scan_dir)
+            # scan_sub_dir may contain <ScanID>
             lima_sub_dir = conf[element]['scan_sub_dir'].format(ScanID=scan_id)
-            image_folder = os.path.join(scan_dir, lima_dir, lima_sub_dir)
+            image_folder = os.path.join(lima_dir, lima_sub_dir)
             if not os.path.exists(image_folder):
                 os.makedirs(image_folder)
             index = conf[element]['index']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2
 commit = True
 tag = True
 message = Bump version {current_version} to {new_version}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 # The version is updated automatically with bumpversion
 # Do not update manually
-__version = "0.7.1"
+__version = "0.7.2"
 
 
 setup(


### PR DESCRIPTION
Added an optional parameter to lima_hook macro in order to be able to set a destination folder that may not be accessible from the sardana machine. We had this situation with a detector that writes to a fast access storage folder that is not accessible from the computer that is running the sardana so we cannot use the ScanDir folder (sardana env var). ScanDir is still the default if no parameter is passed.