### PR TITLE
Add support for DataArrayVersion 3

### DIFF
--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -115,6 +115,13 @@ class LimaCtrlMixin(object):
             Type: int,
             DefaultValue: 3000,
             Description: 'Tango client timeout in milliseconds'
+        },
+        'DataArrayVersion': {
+            Type: int,
+            DefaultValue: 2,
+            Description: 'LimaCCDs DataArrayVersion.'
+                         'Supported versions are 2 (LimaCCDs <1.9.17)'
+                         'and 3 (>1.9.17)'
         }
     }
 
@@ -193,7 +200,8 @@ class LimaCtrlMixin(object):
         self._lima = Lima(
             self.LimaCCDDeviceName,
             self._log,
-            self.TangoClientTimeout
+            self.TangoClientTimeout,
+            self.DataArrayVersion
         )
         self._lima.saving.first_image_nb = self.FirstImageNumber
         self._lima.saving.delay_time = self.FirstImageNumberDelayTime


### PR DESCRIPTION
From lima-tango-server version 1.9.17, the DataArrayVersion has been upgraded from 2 to 3. The struct format does not change significantly and actually the one for version 2 was compatible as it is used in the plugin. However there was an assert in client.py checking for version 2 and preventing these data to be processed.

However, to keep a consistency, I updated the way LIMA_DECODER woks in the plugin, so now it is an attribute of the Lima class and it is initilized taking into account the DataArrayVersion, which is set in a controller property. By default, version 2 has been left so no changes need to be done in current applications.

Take into account that the decoding is ONLY used when ref_enabled = false, and the plugin forces all 2D data to use ref_enabled so this only applies for 1D data when ref_enabled is false. It's a specific case but actually used in ALBA, for example, with the Mythen2 detector.