### PR TITLE
Support Windows OS saving

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -285,6 +285,9 @@ class Saving(object):
         self.enabled = False
         self.pattern = ""
         self.config = {}
+        self.windows_saving = False
+        self.windows_drive = ''
+        self.windows_remove_base_path = ''
 
     def filename(self, index):
         scheme = "file"
@@ -308,7 +311,19 @@ class Saving(object):
                         'saving_suffix', 'saving_index_format',
                         'saving_prefix']
         for name in attr_ordered:
-            self.lima[name] = self.config[name]
+            if name == 'saving_directory' and self.windows_saving:
+                saving_directory = self.config["saving_directory"]
+                saving_directory = saving_directory.split(
+                    self.windows_remove_base_path)[-1]
+                if ':' not in self.windows_drive:
+                    self.windows_drive += ':/'
+                elif '/' not in self.windows_drive:
+                    self.windows_drive += '/'
+
+                saving_directory = self.windows_drive + saving_directory
+                self.lima["saving_directory"] = saving_directory
+            else:
+                self.lima[name] = self.config[name]
 
         if self.first_image_nb != 0:
             self.lima["saving_next_number"] = -1

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -122,7 +122,24 @@ class LimaCtrlMixin(object):
             Description: 'LimaCCDs DataArrayVersion.'
                          'Supported versions are 2 (LimaCCDs <1.9.17)'
                          'and 3 (>1.9.17)'
-        }
+        },
+        'WindowsSaving': {
+            Type: bool,
+            Description: 'LimaCCD server is running on Windows OS '
+                         'Machine',
+            DefaultValue: False},
+        'WindowsDrive': {
+            Type: str,
+            Description: 'Drive letter for the storage mounting eg: "L"',
+            DefaultValue: ''},
+        'WindowsRemoveBasePath': {
+            Type: str,
+            Description: 'Linux and Windows mounting different point for the '
+                         'storage, eg: Linux /beamlines/bl31/projects/xxx '
+                         'and Windows L:/projects/xxx. Set /beamlines/bl31/ '
+                         'to remove from the value_ref_pattern to '
+                         'save in windows',
+            DefaultValue: ''}
     }
 
     ctrl_attributes = {
@@ -191,7 +208,9 @@ class LimaCtrlMixin(object):
             Access: DataAccess.ReadWrite,
             Memorize: NotMemorized,
             MaxDimSize: (1000000,)},
-        }
+
+
+    }
 
     axis_attributes = {}
 
@@ -205,6 +224,12 @@ class LimaCtrlMixin(object):
         )
         self._lima.saving.first_image_nb = self.FirstImageNumber
         self._lima.saving.delay_time = self.FirstImageNumberDelayTime
+        if self.WindowsSaving and not self.WindowsDrive:
+            self._log.exception('WindowsDrive must have a value '
+                                'if WindowsSaving is enabled')
+        self._lima.saving.windows_saving = self.WindowsSaving
+        self._lima.saving.windows_drive = self.WindowsDrive
+        self._lima.saving.windows_remove_base_path = self.WindowsRemoveBasePath
         self._latency_time = self.LatencyTime
         self._acquisition = None
         try:

--- a/sardana_limaccd/macro/limaccd.py
+++ b/sardana_limaccd/macro/limaccd.py
@@ -161,7 +161,7 @@ def find_dynamic_variables(string):
 def str_formatting_env_variables(macro_obj, string):
     """
     Function to translate from environment variables to string recursively.
-    It takes an string with keywords that are going to be replaced by their
+    It takes a string with keywords that are going to be replaced by their
     corresponding environment variable value. Hence, the keywords must be
     environment variables with value strings or numbers.
     Everything between curly brackets '{}' will be considered a keyword.
@@ -182,9 +182,11 @@ def str_formatting_env_variables(macro_obj, string):
         if var not in current_env:
             invalid_variables.append(var)
     if invalid_variables:
-        raise ValueError("Dynamic variables '{}' do not exist in environment".format(invalid_variables))
+        raise ValueError("Dynamic variables '{}' do not exist in environment"
+                         "".format(invalid_variables))
 
-    environment_variables = {var : current_env[var] for var in dynamic_variables}
+    environment_variables = {var : current_env[var] for var in
+                             dynamic_variables}
     formatted_str = string.format(**environment_variables)
 
     if find_dynamic_variables(formatted_str):
@@ -211,15 +213,18 @@ class lima_hook(Macro):
                 continue
             # Prepare the Value Reference Pattern for the element
             # directory may contain any environment variable
-            lima_dir = str_formatting_env_variables(self, conf[element]['directory'])
+            lima_dir = str_formatting_env_variables(
+                self, conf[element]['directory'])
             # scan_sub_dir may contain any environment variable
-            lima_sub_dir = str_formatting_env_variables(self, conf[element]['scan_sub_dir'])
+            lima_sub_dir = str_formatting_env_variables(
+                self, conf[element]['scan_sub_dir'])
             image_folder = os.path.join(lima_dir, lima_sub_dir)
             if not os.path.exists(image_folder):
                 os.makedirs(image_folder)
             index = conf[element]['index']
             # scan_sub_dir may contain any environment variable
-            prefix = str_formatting_env_variables(self, conf[element]['prefix'])
+            prefix = str_formatting_env_variables(
+                self, conf[element]['prefix'])
             suffix = conf[element]['suffix'].split('.')[1]
             # TODO Find a nice way
             image_path = "file://"+image_folder

--- a/sardana_limaccd/macro/limaccd.py
+++ b/sardana_limaccd/macro/limaccd.py
@@ -33,7 +33,8 @@ class set_lima_conf(Macro):
       "suffix": ".h5",
       "index": "05d",
       "scan_sub_dir": "scan_{ScanID:04d}",
-      "directory": "{ScanDir}/xp3"
+      "directory": "{ScanDir}/xp3",
+      "create_folders": True
 
     """
     param_def = [
@@ -49,7 +50,8 @@ class set_lima_conf(Macro):
         if alias not in conf:
             raise ValueError('The detector is not on the configuration. '
                              'Use def_lima_conf macro to include it.')
-
+        if parameter == 'create_folders':
+            value = eval(value)
         conf[alias][parameter] = value
         self.setEnv(LIMA_ENV, conf)
 
@@ -62,7 +64,8 @@ class get_lima_conf(Macro):
       "suffix": ".h5",
       "index": "05d",
       "scan_sub_dir": "scan_{ScanID:04d}",
-      "directory": "{ScanDir}/xp3"
+      "directory": "{ScanDir}/xp3",
+      "create_folders": True
 
     """
     param_def = [
@@ -96,7 +99,8 @@ class def_lima_conf(Macro):
         suffix: ".edf",
         index: "04d",
         scan_sub_dir: "scan_{ScanID:04d}",
-        directory: "{ScanDir}/<lima_channel>"
+        directory: "{ScanDir}/<lima_channel>",
+        create_folders: True
     """
     param_def = [['lima_channel', Type.TwoDExpChannel, None, ''],
                  ['parameters', [
@@ -118,7 +122,8 @@ class def_lima_conf(Macro):
                        "suffix": ".edf",
                        "index": "04d",
                        "scan_sub_dir": "scan_{ScanID:04d}",
-                       "directory": "{{ScanDir}}/{}".format(lima_channel)}
+                       "directory": "{{ScanDir}}/{}".format(lima_channel),
+                       "create_folders": True}
 
         conf[alias].update(dict(parameters))
         self.setEnv(LIMA_ENV, conf)
@@ -133,6 +138,7 @@ class udef_lima_conf(Macro):
         index: "04d",
         scan_sub_dir: "scan_{ScanID:04d}",
         directory: {ScanDir}/<lima_channel>
+        create_folders: True
     """
     param_def = [['lima_channel', Type.TwoDExpChannel, None, '']]
 
@@ -195,6 +201,22 @@ def str_formatting_env_variables(macro_obj, string):
 
     return formatted_str
 
+def create_image_folder(macro_obj, channel_conf):
+    # Prepare the Value Reference Pattern for the element
+    # directory may contain any environment variable
+    lima_dir = str_formatting_env_variables(
+        macro_obj, channel_conf['directory'])
+    # scan_sub_dir may contain any environment variable
+    lima_sub_dir = str_formatting_env_variables(
+        macro_obj, channel_conf['scan_sub_dir'])
+    image_folder = os.path.join(lima_dir, lima_sub_dir)
+    # Check if the creation of the folders is needed, if the key
+    # does not exist the hook will create the folder by default.
+    create_folders = channel_conf.get('create_folders', True)
+    if create_folders and not os.path.exists(image_folder):
+        os.makedirs(image_folder)
+    return image_folder
+
 
 class lima_hook(Macro):
     """
@@ -208,24 +230,16 @@ class lima_hook(Macro):
         mg_active = self.getEnv('ActiveMntGrp')
         mg = self.getMeasurementGroup(mg_active)
 
-        for element in mg.getChannelLabels():
-            if element not in conf:
+        for channel in mg.getChannelLabels():
+            if channel not in conf:
                 continue
-            # Prepare the Value Reference Pattern for the element
-            # directory may contain any environment variable
-            lima_dir = str_formatting_env_variables(
-                self, conf[element]['directory'])
-            # scan_sub_dir may contain any environment variable
-            lima_sub_dir = str_formatting_env_variables(
-                self, conf[element]['scan_sub_dir'])
-            image_folder = os.path.join(lima_dir, lima_sub_dir)
-            if not os.path.exists(image_folder):
-                os.makedirs(image_folder)
-            index = conf[element]['index']
-            # scan_sub_dir may contain any environment variable
+
+            channel_conf = conf[channel]
+            image_folder = create_image_folder(self, channel_conf)
+            index = channel_conf['index']
             prefix = str_formatting_env_variables(
-                self, conf[element]['prefix'])
-            suffix = conf[element]['suffix'].split('.')[1]
+                self, channel_conf['prefix'])
+            suffix = channel_conf['suffix'].split('.')[1]
             # TODO Find a nice way
             image_path = "file://"+image_folder
             image_name = "{}".format(prefix)
@@ -235,7 +249,7 @@ class lima_hook(Macro):
             image_name += ".{}".format(suffix)
             image_pattern = os.path.join(image_path, image_name)
             self.info('Configured %s channel according to the lima '
-                      'configuration: %s', element, image_pattern)
+                      'configuration: %s', channel, image_pattern)
             # TODO Use the MntGrp API
-            self.set_meas_conf('ValueRefPattern', image_pattern, element, mg)
-            self.set_meas_conf('ValueRefEnabled', True, element, mg)
+            self.set_meas_conf('ValueRefPattern', image_pattern, channel, mg)
+            self.set_meas_conf('ValueRefEnabled', True, channel, mg)


### PR DESCRIPTION
The way to mount the storage on Linux and Windows is different. This generate a problem if Sardana is running on Linux and LimaCCDs is running on Windows. I added properties to configure LimaCCD in case the server is running on Windows and it saves on the same storage than Sardana. 