### PR TITLE
Support multiple frames per file and fix double counting

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -257,8 +257,7 @@ class Acquisition(object):
         return frames
 
     def next_ref_frame(self):
-        last = self["last_image_saved"]
-        n = self._save_next_number + last
+        n = self._save_next_number
         return self.saving.filename(n)
 
     def next_ref_frames(self):


### PR DESCRIPTION
Right now, in software synchronization, when performing a step scan with frames_per_file=1 we get a "double" increment of the index shown in spock references:

```python
Door_macroserver_1 [188]: ascan dmot01 1 10 10 .1
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #4 started at Wed Jun  5 18:38:34 2024. It will take at least 0:00:12.872699
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0000.h5  4.50253 
   1        1.9     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0002.h5  5.57369 
   2        2.8     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0004.h5  6.63355 
   3        3.7     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0006.h5  7.69214 
   4        4.6     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0008.h5  8.72817 
   5        5.5     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0010.h5  9.78094 
   6        6.4     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0012.h5  10.8375 
   7        7.3     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0014.h5  11.9007 
   8        8.2     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0016.h5  12.9425 
   9        9.1     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0018.h5   13.991 
   10        10     h5file:///tmp//fsm_sim1/scan_0003/fsm_sim1_0020.h5  15.0457 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #4 ended at Wed Jun  5 18:38:49 2024, taking 0:00:15.183837. Dead time 82.2% (setup time 10.6%, motion dead time 78.5%)
```
when in reality the files are writen in the correct numbering (0 to 10 in the previous case). Also, when setting frames_per_file bigger than 1, we get wrong references as well:
```python
Door_macroserver_1 [184]: ascan dmot01 1 10 10 .1
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #2 started at Wed Jun  5 18:35:14 2024. It will take at least 0:00:10.987081
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0000.h5  5.71124 
   1        1.9     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0001.h5  6.78561 
   2        2.8     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0002.h5  7.83107 
   3        3.7     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0003.h5  8.88697 
   4        4.6     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0004.h5  9.93309 
   5        5.5     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0005.h5  10.9947 
   6        6.4     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0006.h5  12.0404 
   7        7.3     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0007.h5  13.1087 
   8        8.2     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0008.h5  14.1572 
   9        9.1     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0009.h5  15.2219 
   10        10     h5file:///tmp//fsm_sim1/scan_0001/fsm_sim1_0011.h5   16.276 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #2 ended at Wed Jun  5 18:35:30 2024, taking 0:00:16.431133. Dead time 64.7% (setup time 28.6%, motion dead time 61.3%)
```
In this case since we get the last_image_saved from lima, if we set frames_per_file 10 we get secuential numbering (adding nr of collected images to lima frame 0) until the 10, where we jump and extra one (adding number 10 to lima frame 1). When in reality we have only 2 files written, index 0000 with 10 frames and index 0001 with 1 frame in this case.

For hardware synchronization, the index is ok when working with frames_per_file=1 as an array is generated each time read_frames is called. However this is not compatible with multiple frames_per_file.

This MR addresses both issues, fixes the indexing in step scan for frames_per_file=1 and adds support for multiple frame_per_file in both modes (SW and HW) so the references are ok. For example, frames_per_file=10 will result in:

```python
Door_macroserver_1 [194]: ascanct dmot01 1 10 20 .01
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #6 started at Wed Jun  5 18:47:32 2024. It will take at least 0:00:00
Motor positions and relative timestamp (dt) columns contains theoretical values

  Motor   Velocity[u/s]   Acceleration[s]   Deceleration[s]    Start[u]   End[u] 
  dmot01        45               2                 2             -44      55.45  

 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5     2    
   1        1.45    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.01  
   2        1.9     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.02  
   3        2.35    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.03  
   4        2.8     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.04  
   5        3.25    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.05  
   6        3.7     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.06  
   7        4.15    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.07  
   8        4.6     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.08  
   9        5.05    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0000.h5    2.09  
   10       5.5     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.1   
   11       5.95    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.11  
   12       6.4     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.12  
   13       6.85    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.13  
   14       7.3     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.14  
   15       7.75    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.15  
   16       8.2     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.16  
   17       8.65    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.17  
   18       9.1     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.18  
   19       9.55    h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0001.h5    2.19  
   20        10     h5file:///tmp//fsm_sim1/scan_0005/fsm_sim1_0002.h5    2.2   
Overshoot was corrected
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #6 ended at Wed Jun  5 18:47:58 2024, taking 0:00:25.926937. Dead time 94.1% (setup time 5.9%, motion dead time 94.1%)
```