### PR TITLE
Add dataset path in reference for VDS in h5 Sardana recorder

### DIFF
--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -139,7 +139,13 @@ class LimaCtrlMixin(object):
                          'and Windows L:/projects/xxx. Set /beamlines/bl31/ '
                          'to remove from the value_ref_pattern to '
                          'save in windows',
-            DefaultValue: ''}
+            DefaultValue: ''},
+        'H5DatasetPath': {
+            Type: str,
+            Description: 'Path inside the h5 files where the data is stored, '
+                         'to assing properly as VDS when creating the h5 file'
+                         '[default= "entry_0000/measurement/data"]',
+            DefaultValue: 'entry_0000/measurement/data'}
     }
 
     ctrl_attributes = {
@@ -208,8 +214,6 @@ class LimaCtrlMixin(object):
             Access: DataAccess.ReadWrite,
             Memorize: NotMemorized,
             MaxDimSize: (1000000,)},
-
-
     }
 
     axis_attributes = {}
@@ -332,8 +336,10 @@ class LimaCtrlMixin(object):
     def RefOne(self, axis):
         if self.is_soft_gate_or_trigger:
             res = self._acquisition.next_ref_frame()
+            res = res + "::" + self.H5DatasetPath
         else:
             res = self._acquisition.next_ref_frames()
+            res = [ref + "::" + self.H5DatasetPath for ref in res]
         return res
 
     def StopOne(self, axis):


### PR DESCRIPTION
When using the Sardana `NXscanH5_FileRecorder` it tries to create a Virtual DataSet for referenced 2D data.
However, it expects the path of the dataset inside the h5 file to be properly created and this is not provided by the controller. With this change, the reference will have the dataset path after the h5 filepath so the VDS are being created and working:

```python
Door_macroserver_1 [203]: ascan dmot01 1 5 5 .1
Error taking pre-scan snapshot of motLab03 (tango://localhost:10000/motor/lab_ipap_ctrl/3)
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #9 started at Wed Jun  5 18:56:59 2024. It will take at least 0:00:07.644797
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0000.h5::entry_0000/measurement/data   4.3093 
   1        1.8     h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0001.h5::entry_0000/measurement/data  5.30705 
   2        2.6     h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0002.h5::entry_0000/measurement/data  6.28514 
   3        3.4     h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0003.h5::entry_0000/measurement/data  7.27613 
   4        4.2     h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0004.h5::entry_0000/measurement/data  8.26271 
   5         5      h5file:///tmp/fsm_sim1/scan_0008/fsm_sim1_0005.h5::entry_0000/measurement/data   9.2517 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #9 ended at Wed Jun  5 18:57:08 2024, taking 0:00:09.393667. Dead time 78.2% (setup time 15.4%, motion dead time 75.5%)
```

![image](https://github.com/ALBA-Synchrotron/sardana-limaccd/assets/104160150/45a751df-b3d3-48d1-ad84-467c9ca53921)
![image](https://github.com/ALBA-Synchrotron/sardana-limaccd/assets/104160150/4acb73f2-95cd-4ab1-9f8d-4b2873753a8a)
