### PR TITLE
H5 vds reference corrections

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -278,7 +278,7 @@ class Acquisition(object):
 class Saving(object):
 
     FILE_PATTERN = \
-        "{scheme}://{saving_directory}/{saving_prefix}{index}{saving_suffix}"
+        "{scheme}://{saving_directory}/{saving_prefix}{index}{saving_suffix}{dataset}"
 
     def __init__(self, lima):
         self.lima = lima
@@ -291,14 +291,17 @@ class Saving(object):
         self.windows_saving = False
         self.windows_drive = ''
         self.windows_remove_base_path = ''
+        self.dataset_path = ''
 
     def filename(self, index):
         scheme = "file"
+        dataset_path = ""
         if self.config["saving_format"] == "HDF5":
             scheme = "h5file"
+            dataset_path = self.dataset_path
         index = self.config["saving_index_format"] % index
         return self.FILE_PATTERN.format(
-            scheme=scheme, index=index, **self.config
+            scheme=scheme, index=index, **self.config, dataset=dataset_path
         )
 
     def prepare(self):

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -258,6 +258,9 @@ class LimaCtrlMixin(object):
                 AcqSynch.HardwareStart: AcqSynch.HardwareGate
             })
 
+        if self.H5DatasetPath:
+            self._lima.saving.dataset_path = "::" + self.H5DatasetPath
+
     @property
     def is_soft_gate_or_trigger(self):
         return self._synchronization in \
@@ -356,10 +359,8 @@ class LimaCtrlMixin(object):
     def RefOne(self, axis):
         if self.is_soft_gate_or_trigger:
             res = self._acquisition.next_ref_frame()
-            res = res + "::" + self.H5DatasetPath
         else:
             res = self._acquisition.next_ref_frames()
-            res = [ref + "::" + self.H5DatasetPath for ref in res]
         return res
 
     def StopOne(self, axis):

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -145,7 +145,7 @@ class LimaCtrlMixin(object):
             Description: 'Path inside the h5 files where the data is stored, '
                          'to assing properly as VDS when creating the h5 file'
                          '[default= "entry_0000/measurement/data"]',
-            DefaultValue: 'entry_0000/measurement/data'}
+            DefaultValue: 'entry_0000/measurement/data'},
         'HardwareStartConvert': {
             Type: str,
             Description: 'HW/SW Start synchronization will be converted to '


### PR DESCRIPTION
Hi,
Previous merge request was not complete, it was not checking if saving.format was HDF5 before adding the dataset path. Now it is only being added when lima is saving in h5 format:

```python
Door_macroserver_1 [24]: ascan dmot01 1 5 4 .1
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #17 started at Thu Jun  6 12:34:28 2024. It will take at least 0:00:06.156854
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      file:///tmp/fsm_sim1/scan_0016/fsm_sim1_0000.edf  3.41549 
   1         2      file:///tmp/fsm_sim1/scan_0016/fsm_sim1_0000.edf  4.52006 
   2         3      file:///tmp/fsm_sim1/scan_0016/fsm_sim1_0000.edf  5.65074 
   3         4      file:///tmp/fsm_sim1/scan_0016/fsm_sim1_0000.edf  6.75248 
   4         5      file:///tmp/fsm_sim1/scan_0016/fsm_sim1_0000.edf  7.85812 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #17 ended at Thu Jun  6 12:34:36 2024, taking 0:00:08.040035. Dead time 75.7% (setup time 18.1%, motion dead time 71.5%)

Door_macroserver_1 [25]: set_lima_conf fsm_sim1 suffix .h5

Door_macroserver_1 [26]: lima_hook
Configured fsm_sim1 channel according to the lima configuration: file:///tmp/fsm_sim1/scan_0017/fsm_sim1_{index:04d}.h5

Door_macroserver_1 [27]: ascan dmot01 1 5 4 .1
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #18 started at Thu Jun  6 12:35:40 2024. It will take at least 0:00:06.156854
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp/fsm_sim1/scan_0017/fsm_sim1_0000.h5::entry_0000/measurement/data   3.4383 
   1         2      h5file:///tmp/fsm_sim1/scan_0017/fsm_sim1_0000.h5::entry_0000/measurement/data  4.55554 
   2         3      h5file:///tmp/fsm_sim1/scan_0017/fsm_sim1_0000.h5::entry_0000/measurement/data  5.66666 
   3         4      h5file:///tmp/fsm_sim1/scan_0017/fsm_sim1_0000.h5::entry_0000/measurement/data  6.77721 
   4         5      h5file:///tmp/fsm_sim1/scan_0017/fsm_sim1_0000.h5::entry_0000/measurement/data  7.89044 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #18 ended at Thu Jun  6 12:35:48 2024, taking 0:00:08.056352. Dead time 74.9% (setup time 18.9%, motion dead time 71.3%)
```

Also, by default dataset value is "entry_0000/measurement/data" but it can be disabled by leaving the property empty and no dataset will be added in the reference, even for h5 files:

```python
Door_macroserver_1 [30]: ascan dmot01 1 5 4 .1
Operation will be saved in /tmp/test_frames.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #20 started at Thu Jun  6 12:37:54 2024. It will take at least 0:00:06.156854
 #Pt No    dmot01   fsm_sim1     dt   
   0         1      h5file:///tmp/fsm_sim1/scan_0019/fsm_sim1_0000.h5  3.44769 
   1         2      h5file:///tmp/fsm_sim1/scan_0019/fsm_sim1_0000.h5  4.57036 
   2         3      h5file:///tmp/fsm_sim1/scan_0019/fsm_sim1_0000.h5  5.70364 
   3         4      h5file:///tmp/fsm_sim1/scan_0019/fsm_sim1_0000.h5   6.8053 
   4         5      h5file:///tmp/fsm_sim1/scan_0019/fsm_sim1_0000.h5  7.92432 
Operation saved in /tmp/test_frames.h5 (HDF5::NXscan)
Scan #20 ended at Thu Jun  6 12:38:02 2024, taking 0:00:08.071962. Dead time 75.2% (setup time 18.6%, motion dead time 71.3%)
```

I think that now the basic functionality is complete.