### PR TITLE
Add support for DataArrayVersion 4 and make it default

### DIFF
--- a/sardana_limaccd/client.py
+++ b/sardana_limaccd/client.py
@@ -25,7 +25,8 @@ class LimaImageFormat(struct.Struct):
 
     # Version: Format
     DArrayPackStr = {2: "<IHHIIHHHHHHHHIIIIIIII",
-                     3: "<IHHIIHHHHHHHHIIIIIIQ"}
+                     3: "<IHHIIHHHHHHHHIIIIIIQ",
+                     4: "<IHHIIHHHHHHHHIIIIIIQQII"}
 
     def __init__(self, dataArrayVersion=2):
         self.dataArrayVersion = dataArrayVersion

--- a/sardana_limaccd/ctrl/LimaCCDCtrl.py
+++ b/sardana_limaccd/ctrl/LimaCCDCtrl.py
@@ -118,10 +118,10 @@ class LimaCtrlMixin(object):
         },
         'DataArrayVersion': {
             Type: int,
-            DefaultValue: 2,
+            DefaultValue: 4,
             Description: 'LimaCCDs DataArrayVersion.'
                          'Supported versions are 2 (LimaCCDs <1.9.17)'
-                         'and 3 (>1.9.17)'
+                         '3 (>=1.9.17) and 4 (>=1.10)'
         },
         'WindowsSaving': {
             Type: bool,


### PR DESCRIPTION
Compatibility with DataArrayVersion 3 was added in: https://github.com/ALBA-Synchrotron/sardana-limaccd/pull/19 
for lima-tango-server version 1.9.17 and above. However in 1.10 DataArrayVersion 4 has been added so this PR adds as well its compatibility.
The DataArrayPackStr can be found in the LimaCCDs tango server code:
https://github.com/esrf-bliss/Lima-tango-python/blob/0db3a266f9100f2ad7b9365e00b32323e25712d5/Lima/Server/LimaCCDs.py#L265
